### PR TITLE
Returning values should not have any brackets

### DIFF
--- a/src/handler/create.rs
+++ b/src/handler/create.rs
@@ -12,7 +12,7 @@ static QUERY: &str = "
 INSERT INTO spell
 (name, damage)
 VALUES ($1, $2)
-RETURNING (id, name, damage, created_at, updated_at)
+RETURNING id, name, damage, created_at, updated_at
 ";
 
 pub async fn create(state: AppState, spell: CreateSpellBody) -> Result<Spell, Box<dyn Error>> {


### PR DESCRIPTION
When you send a post request to create a new spell you get this error:

```
2024-03-17T00:33:03.167232Z ERROR spellbook::handler: no column found for name: id
2024-03-17T00:33:03.167283Z ERROR tower_http::trace::on_failure: response failed classification=Status code: 500 Internal Server Error latency=142 ms
```
This is because you don't need the brackets on the RETURNING clause.

Postgres docs has some examples on this
https://www.postgresql.org/docs/current/sql-update.html

The database is still modified, just the returning values break it and return a 500.