### PR TITLE
Removing mutex

### DIFF
--- a/src/handler/create.rs
+++ b/src/handler/create.rs
@@ -16,12 +16,13 @@ RETURNING (id, name, damage, created_at, updated_at)
 ";
 
 pub async fn create(state: AppState, spell: CreateSpellBody) -> Result<Spell, Box<dyn Error>> {
-    let db = &state.lock().await.database;
+    let db = &state.database;
 
     let spell = sqlx::query_as(QUERY)
         .bind(&spell.name)
         .bind(&spell.damage)
-        .fetch_one(db).await?;
+        .fetch_one(db)
+        .await?;
 
     Ok(spell)
 }

--- a/src/handler/delete.rs
+++ b/src/handler/delete.rs
@@ -5,16 +5,10 @@ static QUERY: &str = "
 DELETE FROM spell WHERE id = $1
 ";
 
-pub async fn delete_spell(
-    state: AppState, id: i64,
-) -> Result<u64, Box<dyn Error>> {
+pub async fn delete_spell(state: AppState, id: i64) -> Result<u64, Box<dyn Error>> {
     tracing::info!("deleting spell: {}", id);
 
-    let s = state.lock().await;
-
-    let res = sqlx::query(QUERY)
-        .bind(id)
-        .execute(&s.database).await?;
+    let res = sqlx::query(QUERY).bind(id).execute(&state.database).await?;
 
     Ok(res.rows_affected())
 }

--- a/src/handler/list.rs
+++ b/src/handler/list.rs
@@ -8,6 +8,6 @@ FROM spell
 ";
 
 pub async fn list_spells(state: AppState) -> Result<Vec<Spell>, Box<dyn Error>> {
-    let db = &state.lock().await.database;
+    let db = &state.database;
     Ok(sqlx::query_as(QUERY).fetch_all(db).await?)
 }

--- a/src/handler/read.rs
+++ b/src/handler/read.rs
@@ -1,8 +1,8 @@
 #![allow(unused_imports)]
 use crate::handler::Spell;
 use crate::state::AppState;
-use std::error::Error;
 use fred::prelude::*;
+use std::error::Error;
 
 static QUERY: &str = "
 SELECT id, name, damage, created_at, updated_at
@@ -10,14 +10,11 @@ FROM spell
 WHERE id = $1
 ";
 
-pub async fn find_by_id(
-    state: AppState, id: i64,
-) -> Result<Option<Spell>, Box<dyn Error>> {
-    let s = state.lock().await;
-
+pub async fn find_by_id(state: AppState, id: i64) -> Result<Option<Spell>, Box<dyn Error>> {
     let res: Option<Spell> = sqlx::query_as(QUERY)
         .bind(id)
-        .fetch_optional(&s.database).await?;
+        .fetch_optional(&state.database)
+        .await?;
 
     tracing::info!("returning database version");
     Ok(res)

--- a/src/handler/update.rs
+++ b/src/handler/update.rs
@@ -1,12 +1,12 @@
 #![allow(unused_imports)]
-use crate::state::AppState;
-use std::error::Error;
 use crate::handler::Spell;
+use crate::state::AppState;
 use fred::prelude::*;
+use std::error::Error;
 
 #[derive(serde::Deserialize)]
 pub struct UpdateBody {
-    pub damage: i32
+    pub damage: i32,
 }
 
 static QUERY: &str = "
@@ -15,16 +15,17 @@ RETURNING id, name, damage, created_at, updated_at
 ";
 
 pub async fn update(
-    state: AppState, id: i64, body: UpdateBody
+    state: AppState,
+    id: i64,
+    body: UpdateBody,
 ) -> Result<Option<Spell>, Box<dyn Error>> {
     tracing::info!("updating spell: {}", id);
-
-    let s = state.lock().await;
 
     let res: Option<Spell> = sqlx::query_as(QUERY)
         .bind(body.damage)
         .bind(id)
-        .fetch_optional(&s.database).await?;
+        .fetch_optional(&state.database)
+        .await?;
 
     Ok(res)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,11 @@
 mod handler;
 mod state;
 use axum::routing::{delete, get, post, put, Router};
-use std::error::Error;
-use sqlx::postgres::PgPoolOptions;
-use std::sync::Arc;
-use tokio::sync::Mutex;
 use dotenv::dotenv;
 use fred::prelude::*;
+use sqlx::postgres::PgPoolOptions;
+use std::error::Error;
+use std::sync::Arc;
 use tower_http::trace::TraceLayer;
 
 #[tokio::main]
@@ -26,7 +25,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let dbpool = PgPoolOptions::new()
         .max_connections(5)
-        .connect(&pg_url).await?;
+        .connect(&pg_url)
+        .await?;
 
     sqlx::migrate!().run(&dbpool).await?;
 
@@ -46,11 +46,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         let _ = redis_pool.flushall::<i32>(false).await;
     }
 
-    let state = Arc::new(
-        Mutex::new(
-            state::StateInternal::new(dbpool, redis_pool)
-        )
-    );
+    let state = Arc::new(state::StateInternal::new(dbpool, redis_pool));
 
     // build our application with a route
     let app = Router::new()
@@ -63,9 +59,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .with_state(state);
 
     // run our app with hyper, listening globally on port 3000
-    let listener = tokio::net::TcpListener::bind(
-        "0.0.0.0:3000",
-    ).await.unwrap();
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
 
     axum::serve(listener, app).await.unwrap();
 


### PR DESCRIPTION
Thanks for your videos !

Wrapping the state of the app in the mutex is not useful in this case as you don't need a mutable access on it. 
Also it defeats the purpose of using a connection pool as the service won't be able to handle request concurrently having to wait for the last request owning the lock to destroy it before being able to access it.